### PR TITLE
group作成/更新画面、候補日入力画面作成

### DIFF
--- a/front/src/components/atoms/Button.tsx
+++ b/front/src/components/atoms/Button.tsx
@@ -5,7 +5,7 @@ interface ButtonProps {
 
 const Button: React.FC<ButtonProps> = ({onClick,title}) => {
     return (
-        <button type="button" className="focus:outline-none text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-900" onClick={onClick}>{title}</button>
+        <button type="button" className="focus:outline-none text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 mb-2 w-28 mx-auto" onClick={onClick}>{title}</button>
     );
 };
 

--- a/front/src/components/molecules/Email.tsx
+++ b/front/src/components/molecules/Email.tsx
@@ -1,7 +1,7 @@
 const Email = () => {
   return (
     <div className="mb-5">
-      <input type="email" id="email" name="name[]" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" placeholder="Emailアドレスを入力してください" required />
+      <input type="email" id="email" name="name[]" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-11/12 m-auto p-2.5" placeholder="Emailアドレスを入力してください" required />
     </div>
   );
 };

--- a/front/src/components/molecules/InputGroupName.tsx
+++ b/front/src/components/molecules/InputGroupName.tsx
@@ -1,0 +1,14 @@
+interface InputGroupNameProps {
+  name: string;
+}
+
+const InputGroupName: React.FC<InputGroupNameProps> = ({name}) => {
+  return (
+    <div className="mb-5 w-full">
+      <input type="text" id="small-input" name={name} className="block w-full p-2 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-xs focus:ring-blue-500 focus:border-blue-500" placeholder="グループ名" value={"高校の友達"}></input>
+      {/* 更新の場合はvalueに元のグループ名が入る。新規作成の場合はvalueはなし */}
+    </div>
+  );
+}
+
+export default InputGroupName;

--- a/front/src/components/molecules/InputGroupName.tsx
+++ b/front/src/components/molecules/InputGroupName.tsx
@@ -4,7 +4,7 @@ interface InputGroupNameProps {
 
 const InputGroupName: React.FC<InputGroupNameProps> = ({name}) => {
   return (
-    <div className="mb-5 w-full">
+    <div className="w-full">
       <input type="text" id="small-input" name={name} className="block w-full p-2 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-xs focus:ring-blue-500 focus:border-blue-500" placeholder="グループ名" value={"高校の友達"}></input>
       {/* 更新の場合はvalueに元のグループ名が入る。新規作成の場合はvalueはなし */}
     </div>

--- a/front/src/components/molecules/PlaceAlert.tsx
+++ b/front/src/components/molecules/PlaceAlert.tsx
@@ -9,7 +9,7 @@ const PlaceAlert: React.FC<PlaceAlertProps> = ({ place, onClick }) => {
       id="alert-additional-content-5"
       className="p-4 border border-gray-300 rounded-lg bg-gray-50 d-flex w-4/5 mx-auto mt-10 flex flex-col text-center h-40 items-center justify-center"
       role="alert"
-    >
+      >
       <div className="mb-4">
         <h3 className="text-lg font-medium text-gray-800 mb-5">
           '{place}'を達成済みにしますか？
@@ -19,7 +19,7 @@ const PlaceAlert: React.FC<PlaceAlertProps> = ({ place, onClick }) => {
         <button
           type="button"
           className="w-24 text-white bg-blue-800 hover:bg-blue-900 focus:ring-4 focus:outline-none focus:ring-blue-200 font-medium rounded-lg text-xs px-3 py-1.5 me-2 text-center inline-flex items-center justify-center"
-        >
+          >
           はい
         </button>
         <button
@@ -27,7 +27,7 @@ const PlaceAlert: React.FC<PlaceAlertProps> = ({ place, onClick }) => {
           className="w-24 text-gray-800 bg-transparent border border-gray-700 hover:bg-gray-800 hover:text-white focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-xs px-3 py-1.5 text-center"
           data-dismiss-target="#alert-additional-content-5"
           aria-label="Close"
-        >
+          >
           いいえ
         </button>
       </div>

--- a/front/src/components/molecules/Title.tsx
+++ b/front/src/components/molecules/Title.tsx
@@ -5,7 +5,7 @@ interface TitleProps {
 
 const Title: React.FC<TitleProps> = ({title, subtitle}) => {
     return (
-        <div className="flex flex-col">
+        <div className="flex flex-col mx-5 my-4">
             <h1 className="text-3xl">{title}</h1>
             <p className="text-sm text-gray-500">{subtitle}</p>
         </div>
@@ -13,3 +13,4 @@ const Title: React.FC<TitleProps> = ({title, subtitle}) => {
 };
 
 export default Title;
+

--- a/front/src/components/organisms/InputDate.tsx
+++ b/front/src/components/organisms/InputDate.tsx
@@ -1,0 +1,2 @@
+import Title from "../molecules/Title";
+import 

--- a/front/src/components/organisms/InputDate.tsx
+++ b/front/src/components/organisms/InputDate.tsx
@@ -1,2 +1,15 @@
 import Title from "../molecules/Title";
-import 
+import Datepicker from "../molecules/Datepicker";
+import Button from "../atoms/Button";
+
+const InputDate: React.FC = () => {
+  return (
+    <div className="flex flex-col">
+      <Title title="Date" subtitle="候補日を入力しよう！" />
+      <Datepicker />
+      <Button title="決定" onClick={() => {} } />
+    </div>
+  );
+};
+
+export default InputDate;

--- a/front/src/components/organisms/InputGroup.tsx
+++ b/front/src/components/organisms/InputGroup.tsx
@@ -1,0 +1,28 @@
+import Title from "../molecules/Title";
+import Email from "../molecules/Email";
+import Button from "../atoms/Button";
+import ColorPicker from "../../hooks/ColorPicker";
+import InputGroupName from "../molecules/InputGroupName";
+
+
+interface InputGroupProps {
+  title: string;
+  subtitle: string;
+}
+
+const InputGroup: React.FC<InputGroupProps> = ({ title, subtitle }) => {
+  return (
+    <div className="flex flex-col">
+      <Title title={title} subtitle={subtitle} />
+      <div className="flex gap-x-4 mx-6">
+        <ColorPicker />
+        <InputGroupName name="家族と" />
+      </div>
+      {Array.from({ length:8 }).map((_, i) => (
+        <Email key={i} />
+      ))}
+      <Button title="決定" onClick={() => {}} />
+    </div>
+  );
+};
+export default InputGroup;

--- a/front/src/components/organisms/InputGroup.tsx
+++ b/front/src/components/organisms/InputGroup.tsx
@@ -14,7 +14,7 @@ const InputGroup: React.FC<InputGroupProps> = ({ title, subtitle }) => {
   return (
     <div className="flex flex-col">
       <Title title={title} subtitle={subtitle} />
-      <div className="flex gap-x-4 mx-6">
+      <div className="flex gap-x-4 mx-6 mb-5 items-center">
         <ColorPicker />
         <InputGroupName name="家族と" />
       </div>

--- a/front/src/hooks/ColorPicker.tsx
+++ b/front/src/hooks/ColorPicker.tsx
@@ -24,9 +24,9 @@ const ColorPicker = () => {
   };
 
   return (
-    <div>
+    <div className="flex items-center">
       <div className="p-1 bg-white rounded shadow cursor-pointer inline-block" onClick={handleClick}>
-        <div className="w-7 h-4 rounded" style={{ background: `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})` }} />
+        <div className="w-7 h-8 rounded" style={{ background: `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})` }} />
       </div>
       {displayColorPicker && (
         <div className="absolute z-20">

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import GoogleMap from '@/components/organisms/GoogleMap';
 import  PlacesList  from '@/components/organisms/PlacesList';
 import InputGroup from '@/components/organisms/InputGroup';
+import InputDate from '@/components/organisms/InputDate';
 import { usePlaces } from '@/hooks/usePlaces';
 const inter = Inter({ subsets: ["latin"] });
 
@@ -12,7 +13,6 @@ export default function Home() {
     <main>
       <GoogleMap />
       <PlacesList places={allPlace} />
-      {/* <InputGroup title="Group" subtitle="一緒に行くグループを作ろう！"/> */}
     </main>
   );
 }

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { Inter } from "next/font/google";
 import GoogleMap from '@/components/organisms/GoogleMap';
 import  PlacesList  from '@/components/organisms/PlacesList';
+import InputGroup from '@/components/organisms/InputGroup';
 import { usePlaces } from '@/hooks/usePlaces';
 const inter = Inter({ subsets: ["latin"] });
 
@@ -11,6 +12,7 @@ export default function Home() {
     <main>
       <GoogleMap />
       <PlacesList places={allPlace} />
+      {/* <InputGroup title="Group" subtitle="一緒に行くグループを作ろう！"/> */}
     </main>
   );
 }


### PR DESCRIPTION
# フロント編
## API's branch

- group作成/更新は同一画面

## What's Changed

- 

## Screenshots or Video

<img width="270" alt="image" src="https://github.com/kazuki1023/hackathon202402/assets/107348301/f88dc544-52cf-4c67-9c49-16bc4cde2938">
<img width=400 src="https://github.com/kazuki1023/hackathon202402/assets/107348301/276dc971-0221-4484-af70-30c9de119d53">

## What's Required Of Reviewer

- デザイン雑でごめんなさい
## Checklist

- [ ] Development で Issue と紐付け済
- [ ] "Review Wanted"タグ付与済み
- [ ] console のエラー確認済
- [ ] コメントは適切か（不要なコメントアウトの削除、PHPDoc などの記述）