### PR TITLE
place一覧とplace作成を切り替え

### DIFF
--- a/front/src/components/organisms/PlacesList.tsx
+++ b/front/src/components/organisms/PlacesList.tsx
@@ -3,16 +3,25 @@ import Title from '../molecules/Title';
 import Place from '../molecules/Place';
 import MenuButton from '../atoms/MenuButton';
 import CreatePlace from '../molecules/CreatePlace';
+import React, { useState } from 'react';
+import CreatePlaceForm from './CreatePlaceForm';
+import { useEffect } from 'react';
 
 interface PlaceListProps {
     places: PlaceType[];
     onClick?: (id: number) => void;
     onMove?: (id: number)=> void;
+    visible: boolean;
+    onChangeVisible: () => void;
 }
 
-const PlaceList: React.FC<PlaceListProps> = ({ places, onClick, onMove }) => { // propsを正しく展開する
+
+
+const PlaceList: React.FC<PlaceListProps> = ({ places, onClick, onMove , visible, onChangeVisible}) => {
+
     return (
-      <div className='z-20'>
+      
+      <div className='z-20' style={{display: visible ? "block" : "none"}}>
         <div className="flex items-center justify-between p-3">
           <Title title="Places I Want to Go" subtitle="行きたい場所をストックしよう！" />
           <MenuButton onClick={() => console.log("Menu button clicked")} />
@@ -26,7 +35,7 @@ const PlaceList: React.FC<PlaceListProps> = ({ places, onClick, onMove }) => { /
                 onMove={() => console.log('Moved place id:', place.id)}
             />
         ))}
-        <CreatePlace onClick={() => console.log('Create place clicked')} />
+        <CreatePlace onClick={onChangeVisible} />
       </div>
     );
 }

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { Inter } from "next/font/google";
+import { useState } from "react";
 import GoogleMap from '@/components/organisms/GoogleMap';
 import  PlacesList  from '@/components/organisms/PlacesList';
 import InputGroup from '@/components/organisms/InputGroup';
@@ -7,15 +8,26 @@ import InputDate from '@/components/organisms/InputDate';
 import { usePlaces } from '@/hooks/usePlaces';
 import Autocomplete from '@/components/molecules/AutoComplete';
 import CreatePlaceForm from '@/components/organisms/CreatePlaceForm';
+import { handleCreatePlaceClick } from '@/components/organisms/CreatePlaceForm';
+import PlaceList from '@/components/organisms/PlacesList';
+import { log } from "console";
 const inter = Inter({ subsets: ["latin"] });
+
 
 export default function Home() {
   const allPlace = usePlaces();
+
+  const [visible, setVisible] = useState(true); // PlaceList の表示状態
+
+  const changeVisible = () => {
+    setVisible(!visible); // visible 状態を切り替える
+  };
+  
   return (
     <main>
       <GoogleMap />
-      <PlacesList places={allPlace} />
-      <CreatePlaceForm onClick={() => console.log("aaa")} />
-    </main>
+      {visible && <PlaceList places={allPlace} visible={visible} onChangeVisible={changeVisible} />}
+      {!visible && <CreatePlaceForm onClick={changeVisible} />} {/* visible が false のときに CreatePlaceForm を表示 */}
+      </main>
   );
 }


### PR DESCRIPTION

# フロント編
## API's branch

- デフォルトのplace一覧の状態でプラスボタンを押すとplace作成画面に切り替わるようにした

## What's Changed

-

## Screenshots or Video

https://github.com/kazuki1023/hackathon202402/assets/107348301/a4e28e3c-2c68-4535-938c-f35381a60c09


## What's Required Of Reviewer

- 

## Linked Issues

-

## Checklist

- [ ] Development で Issue と紐付け済
- [ ] "Review Wanted"タグ付与済み
- [ ] console のエラー確認済
- [ ] コメントは適切か（不要なコメントアウトの削除、PHPDoc などの記述）
